### PR TITLE
A few minor updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
 
       <div class="container">
         Have a pebble app you'd like to submit to the <a href="https://apps.rebble.io">app store</a>? This tool can help! Before you start, make sure you have read <a href="https://developer.rebble.io/developer.pebble.com/guides/appstore-publishing/publishing-an-app/index.html"> the app publishing guidelines </a> and have all the listed resources ready.
-        When you are finished, this tool will generate a zip file which you will then need to send to @joshua on <a href="http://discord.gg/aRUAYFN"> the rebble discord. </a>
-        <br><br> For more information, see the relevant <a href="https://github.com/pebble-dev/wiki/wiki/Preparing-a-new-app-for-the-Rebble-App-Store">rebble wiki page</a>
+        When you are finished, this tool will generate an app bundle, which can then be emailed to <a href="mailto:support@rebble.io">support@rebble.io</a>.
+        <br><br> For more information, see the relevant <a href="https://github.com/pebble-dev/wiki/wiki/Preparing-a-new-app-for-the-Rebble-App-Store">rebble wiki page</a> or talk to someone on the <a href="https://rebble.io/discord"> rebble discord server</a>.
       </div>
     </div>
 
@@ -79,9 +79,6 @@
 
       <div class="md-form form-lg br-sm">
         <label for="i-appname">App Name*:  </label> <i class="fas fa-question-circle" onclick="explain('appname')"></i>
-        <!-- <small id="passwordHelpBlockMD" class="form-text text-muted">
-        This will be the title in the appstore
-        </small> -->
         <input type="text" id="i-appname" class="form-control form-control-lg" name="app-title">
       </div>
       <br>
@@ -97,6 +94,13 @@
         <input type="text" id="i-sourceurl" class="form-control form-control-lg">
       </div>
       <br>
+
+			<div class="md-form form-sm">
+				<label for="i-sourceurl">Developer ID:</label> <i class="fas fa-question-circle" onclick="explain('developerID')"></i><br>
+				<span class="">(If you don't have a developer ID, or have never uploaded an app to the Rebble appstore before, then leave this field blank)</i></span>
+				<input type="text" id="i-developerID" class=" form-control form-control-lg" name="app-title">
+			</div>
+			<br>
 
       <div class="formlabel" id="watchapptype">App Type*: <i class="fas fa-question-circle" onclick="explain('apptype')"></i> </div>
       <div class="custom-control custom-radio m-l-s">
@@ -432,6 +436,8 @@
           <label class="custom-file-label" for="i-f-pbw">Nothing Selected</label>
         </div>
       </div>
+
+
 
       <br><br>
       <button class="btn btn-primary" onclick="build()" id="buildbtn">I'm ready, zip me up!</button>

--- a/main.js
+++ b/main.js
@@ -45,7 +45,7 @@ function calcperccomplete () {
 function start() {
 
   if (! $('#i-iswatchapp').prop("checked")) {
-    $('#watchapponly').hide();
+    $('.watchapponly').hide();
   }
 
   if ($('#i-sw-usesamescreenshots').prop("checked")) {
@@ -171,6 +171,10 @@ function build() {
 
   if ($('#i-sourceurl').val() != null) {
     app.source = $('#i-sourceurl').val();
+  }
+
+  if ($('#i-developerID').val() != null) {
+    app.developerID = $('#i-developerID').val();
   }
 
   if ($('#i-supportemail').val() != null) {
@@ -307,12 +311,15 @@ function build() {
 
   }
 
-  // if (images["i-ban"] == null || images["i-ban"] == "") {
-  //
-  //   buildError("At least one screenshot is required", "i-scr-a-1");
-  //   return;
-  //
-  // } else {
+  if (app.type == "watchface") {
+    //Use screenshot as large icon
+    app.icons = {};
+    if ($('#i-sw-usesamescreenshots').prop("checked")) {
+      app.icons.large = images["i-scr-basalt-1"];
+    } else {
+      app.icons.large = images["i-scr-a-1"];
+    }
+  }
 
   if ((images["i-ban"] == null || images["i-ban"] == "")) {
     //Throw an error only if watchapp. They are optional for faces
@@ -369,6 +376,11 @@ function build() {
   if (app.type == "watchapp") {
     yaml = yaml + "large_icon: icons/Large.png\n"
     yaml = yaml + "small_icon: icons/Small.png\n"
+  } else {
+    yaml = yaml + "large_icon: icons/Large.png\n"
+  }
+  if (app.hasOwnProperty("developerID")) {
+    yaml = yaml + "developer_id: " + app.developerID + "\n"
   }
   yaml = yaml + "title: " + app.title + "\n";
   yaml = yaml + "source: " + app.source + "\n";
@@ -448,6 +460,7 @@ function explain(txt) {
   exp.smallicon = { title: "Small icon", subtitle: "Used in the pebble app applocker.", more: "Required for watch apps only.", opt: false}
   exp.screenshots = { title: "Screenshots", subtitle: "At least one required.", more: "You can use different screenshots per platform, or the same for all.", opt: false}
   exp.banner = { title: "Appstore Banner", subtitle: "A banner advert used in the store.", more: "Make it nice and eye-catching.", opt: false}
+  exp.developerID = { title: "Developer ID", subtitle: "Your developer ID. This ties your apps and watchfaces to you.", more: "If you don't provide one, a new one will be generated for you.", opt: true}
 
   if (exp[txt] != null) {
     $('#helpModalLabel').html(exp[txt].title);


### PR DESCRIPTION
This PR changes the following:

- Adds an optional developer ID field for providing your dev ID
- Uses the first basalt screenshot as large_icon if it's a watchface
- Updates the instructions at the top to mention emailing the .zip (matching the modal)
- Fixes a small bug where the watchapp specific fields weren't hiding on load