### PR TITLE
Use locaStorage instead of sessionStorage for session data.

### DIFF
--- a/html/res/js/devPortal.js
+++ b/html/res/js/devPortal.js
@@ -1552,7 +1552,7 @@ function uuidv4() {
 }
 
 function getUserToken() {
-    return sessionStorage.getItem("access_token");
+    return localStorage.getItem("access_token");
 }
 
 function populateChangeLog() {

--- a/html/res/js/oauth.js
+++ b/html/res/js/oauth.js
@@ -58,11 +58,11 @@ function authPart3(data) {
     try {
 
         data = JSON.parse(data);
-        sessionStorage.setItem("access_token", data.access_token);
-        sessionStorage.setItem("refresh_token", data.refresh_token);
+        localStorage.setItem("access_token", data.access_token);
+        localStorage.setItem("refresh_token", data.refresh_token);
         var d = new Date()
         d.setTime(d.getTime() + data.expires_in);
-        sessionStorage.setItem("expires", d.toISOString());
+        localStorage.setItem("expires", d.toISOString());
         window.location = "/"
         
 
@@ -74,11 +74,11 @@ function authPart3(data) {
 
 function localLogout() {
     //This clears the oauth client data, but doesn't log out from auth.rebble.io
-    sessionStorage.clear();
+    localStorage.clear();
     checkAuthState();
 }
 function logout() {
-    sessionStorage.clear();
+    localStorage.clear();
     window.location = config.endpoint.ssoLogout
 }
 
@@ -86,7 +86,7 @@ function logout() {
 
 function generateAndStoreState() {
     var state = generateState();
-    sessionStorage.setItem('state', state);
+    localStorage.setItem('state', state);
     debugLog("Store state as " + state);
     return state
 }
@@ -99,8 +99,8 @@ function generateState() {
 }
 
 function isStateValid(state) {
-    var expectedState = sessionStorage.getItem("state");
-    sessionStorage.setItem("state", null);
+    var expectedState = localStorage.getItem("state");
+    localStorage.setItem("state", null);
     debugLog("Does local state '" + expectedState + "' match given state '" + state + "'?");
     return (state == expectedState)
 }


### PR DESCRIPTION
The dev portal currently uses sessionStorage to store the access token. This means when all dev portal tabs are closed the browser forgets the session.

This PR replaces that with localstorage, so the user stays logged in. As the access token is long lived, this makes more sense, and provides a better user experience