### PR TITLE
Allow watch faces that only support Emery

### DIFF
--- a/html/res/js/devPortal.js
+++ b/html/res/js/devPortal.js
@@ -1439,7 +1439,13 @@ function submitNewApp() {
     if (shinyNewApp.releaseNotes == "") { newAppValidationError("Release Notes cannot be blank"); return }
     //At least one screenshot
 
-    if ($('#i-screenshot-a-1-f').prop('files')[0] == undefined && $('#i-screenshot-b-1-f').prop('files')[0] == undefined && $('#i-screenshot-c-1-f').prop('files')[0] == undefined && $('#i-screenshot-d-1-f').prop('files')[0] == undefined && $('#i-screenshot-e-1-f').prop('files')[0] == undefined) {
+    if (
+        $('#i-screenshot-a-1-f').prop('files')[0] == undefined &&
+        $('#i-screenshot-b-1-f').prop('files')[0] == undefined &&
+        $('#i-screenshot-c-1-f').prop('files')[0] == undefined &&
+        $('#i-screenshot-d-1-f').prop('files')[0] == undefined &&
+        $('#i-screenshot-e-1-f').prop('files')[0] == undefined
+    ) {
         newAppValidationError("Provide at least one screenshot")
         return
     }


### PR DESCRIPTION
I've built a watch face for the Pebble Time 2 (and only support 200x228 px screen size). I tried to upload it and attached a screenshot for Emery but no other platforms and got an error "Provide at least one screenshot".

I believe this should fix the issue.